### PR TITLE
Fix enums for consumers using isolated modules.

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -6,7 +6,7 @@ import {ArrayEntityList, EntityList, PackedArrayEntityList} from './datatypes/en
 
 type MaskKind = 'withMask' | 'withoutMask' | 'trackMask';
 
-const enum QueryFlavor {
+enum QueryFlavor {
   current = 1, added = 2, removed = 4, changed = 8, addedOrChanged = 16, changedOrRemoved = 32,
   addedChangedOrRemoved = 64
 }

--- a/src/refindexer.ts
+++ b/src/refindexer.ts
@@ -21,7 +21,7 @@ interface Selector {
   sourceSeq?: number;
 }
 
-const enum Action {
+enum Action {
   REFERENCE = 0, UNREFERENCE = 2 ** 30, RELEASE = 2 ** 31
 }
 

--- a/src/system.ts
+++ b/src/system.ts
@@ -16,7 +16,7 @@ export interface SystemType<S extends System> {
 }
 
 
-export const enum RunState {
+export enum RunState {
   RUNNING, STOPPED
 }
 


### PR DESCRIPTION
When importing `@lastolivegames/becsy` in a composite project or a project using the `isolatedModules` flag, the following error is encountered:

``` 
node_modules/@lastolivegames/becsy/index.umd.d.ts:104:37 - error TS2748: Cannot access ambient const enums when the '--isolatedModules' flag is provided.

104 type QueryFlavorName = keyof typeof QueryFlavor;
                                        ~~~~~~~~~~~
```

This PR moves all `const enum` to `enum` to avoid the above interoperability issue. 

Let me know what you think!