### PR TITLE
Run the initialize functions within the default frame

### DIFF
--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -237,7 +237,12 @@ export class Dispatcher {
   }
 
   async initialize(): Promise<void> {
+    this.default.frame.begin();
     await Promise.all(this.systems.map(system => system.initialize()));
+    this.flush();
+    this.default.frame.end();
+    // This is not a frame
+    STATS: this.stats.frames -= 1;
   }
 
   async execute(time?: number, delta?: number): Promise<void> {

--- a/tests/system.test.ts
+++ b/tests/system.test.ts
@@ -1,4 +1,4 @@
-import {System, World} from '../src';
+import {Entity, System, World} from '../src';
 
 let message: string;
 
@@ -17,7 +17,6 @@ class SystemB extends System {
   }
 }
 
-
 describe('attaching systems', () => {
 
   test('attach a system', async() => {
@@ -26,4 +25,18 @@ describe('attaching systems', () => {
     expect(message).toBe('hello');
   });
 
+  test('creating and holding an entity during initialize', async() => {
+    class TestComponent {}
+
+    let output: Entity;
+    await World.create({
+      defs: [TestComponent, class extends System {
+        initialize() {
+          output = this.createEntity(TestComponent).hold();
+        }
+      }]
+    });
+
+    expect(output!.has(TestComponent)).toBe(true);
+  });
 });


### PR DESCRIPTION
At the moment initialize functions are not run within a frame, so any entity created via `createEntity` is marked as invalid, and cannot be interacted with further. This first surfaced in `0.8.2` with the new entity validity checking.

A minimal case:

```
await World.create({
  defs: [TestComponent, class extends System {
    initialize() {
      output = this.createEntity(TestComponent).hold();
    }
  }]
});
```

An example error:

```
entity.ts:199 Uncaught Error: Entity handle no longer valid
    at EntityImpl.__checkValid (entity.ts:199)
    at EntityImpl.hold (entity.ts:173)
    at eval (eval at return (registry.ts:49), <anonymous>:17:29)
    at EntityPool.return (registry.ts:49)
    at EntityPool.returnTemporaryBorrows (registry.ts:39)
    at Registry.flush (registry.ts:124)
    at Dispatcher.flush (dispatcher.ts:276)
    at Dispatcher.createEntity (dispatcher.ts:284)
```

I went ahead and created a test + PR for this, hope that's ok; happy to discuss the approach further :)